### PR TITLE
Bugfix tela cadastro pat

### DIFF
--- a/src/planoTrabalho/planoTrabalhoPrevia/adicionarPAT.js
+++ b/src/planoTrabalho/planoTrabalhoPrevia/adicionarPAT.js
@@ -10,6 +10,11 @@ const horaInicioNodeDom = document.getElementById("hora_inicio")
 const horaFimNodeDom = document.getElementById("hora_fim")
 const diaDaSemanaNodeDom = document.getElementById("dia_semana")
 const btnAdcionar = document.getElementById("adicionar_horario")
+if (filteredPAT.length !== 0) {
+    const selectGradeHorario = document.querySelector("#grade_horaria")
+    selectGradeHorario.innerHTML = ""
+}
+
 for (horario of filteredPAT) {
     includePATOnInterface(
         horario.diaDaSemana,


### PR DESCRIPTION
Adicionada condição para verificação da existência de Prévias de PAT , caso um PAT estiver em edição com horários já cadastrados eles serão removidos da grade do cadastro e serão substituídos pelos horários de PAT da prévia.